### PR TITLE
Allow for non-Minkowski metric

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InverseDistanceWeighting"
 uuid = "6a8e3230-34bb-5a86-b9da-9f7447a06da5"
 author = "Júlio Hoffimann <julio.hoffimann@gmail.com>"
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -24,6 +24,7 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 
 [targets]
-test = ["GeoStatsBase", "Pkg", "VisualRegressionTests", "Plots", "ImageMagick", "QuartzImageIO", "Test"]
+test = ["GeoStatsBase", "Pkg", "VisualRegressionTests", "Plots", "ImageMagick", "Distances", "QuartzImageIO", "Test"]

--- a/src/InverseDistanceWeighting.jl
+++ b/src/InverseDistanceWeighting.jl
@@ -58,7 +58,12 @@ function solve(problem::EstimationProblem, solver::InvDistWeight)
       varσ = Vector{V}(undef, npoints(pdomain))
 
       # fit search tree
-      kdtree = KDTree(X, varparams.distance)
+      M = varparams.distance
+      if M isa NearestNeighbors.MinkowskiMetric
+        tree = KDTree(X, M)
+      else
+        tree = BruteTree(X, M)
+      end
 
       # keep track of estimated locations
       estimated = falses(npoints(pdomain))
@@ -83,7 +88,7 @@ function solve(problem::EstimationProblem, solver::InvDistWeight)
         if !estimated[location]
           coordinates!(coords, pdomain, location)
 
-          idxs, dists = knn(kdtree, coords, k)
+          idxs, dists = knn(tree, coords, k)
 
           weights = one(V) ./ dists
           weights /= sum(weights)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using GeoStatsBase
 using InverseDistanceWeighting
 using Plots; gr(size=(1000,400))
 using VisualRegressionTests
+using Distances
 using Test, Pkg
 
 # workaround GR warnings
@@ -28,5 +29,19 @@ end
 
   if visualtests
     @plottest contourf(solution) joinpath(datadir,"solution.png") !istravis
+  end
+end
+
+@testset "Haversine" begin
+  geodata = PointSetData(OrderedDict(:variable => [4.0,-1.0,3.0]), [50.0 100.0 200.0; -30.0 30.0 10.0])
+  domain  = RegularGrid((1.0, -89.0), (359.0, 89.0), dims=(200, 100))
+  problem = EstimationProblem(geodata, domain, :variable)
+
+  solver = InvDistWeight(:variable => (distance=Haversine(1.0),))
+
+  solution = solve(problem, solver)
+
+  if visualtests
+    @plottest contourf(solution) joinpath(datadir,"Haversine_solution.png") !istravis
   end
 end


### PR DESCRIPTION
This tiny change checks if the distance used is a `MinkowskiMetric` to use NearestNeighbors.jl's `KDTree`. Otherwise (e.g., when using the `Haversine` distance), a `BruteTree` is used instead. This allows to use the package with non-Minkowski metrics. 

With this PR, the following MWE works as expected 😄 

```julia
using Plots, GeoStats, InverseDistanceWeighting, Distances
# data
x = [50.0, 100.0, 200.0]
y = [-30.0, 30.0, 10.0]
z = [4.0, -1.0, 3.0]
# list of properties with coordinates
data = OrderedDict(:variable => z)
coord = [(lon,lat) for (lon,lat) in zip(x,y)]
# define spatial data
sdata = PointSetData(data, coord)
# the solution domain (basically a grid covering the entire globe)
dims = (180, 89)
start = (1.0, -89.0)
finish = (359.0, 89.0)
sdomain = RegularGrid(start, finish, dims=dims)
# define estimation problem for any data column(s) (e.g. :precipitation)
problem = EstimationProblem(sdata, sdomain, :variable)
# axes for plots
xs = range(start[1], stop=finish[1], length=dims[1])
ys = range(start[2], stop=finish[2], length=dims[2])
# Plotting solution with data on top
plts = Any[]
tit(x) = string(x.distance)
for NT in [NamedTuple(),
           (distance=Chebyshev(),),
           (distance=Haversine(1.0),),
           (distance=Minkowski(3.0),)]
    solver = InvDistWeight(:variable => NT)
    solution = GeoStats.solve(problem, solver)
    zs = permutedims(reshape(solution.mean[:variable], size(solution.domain)), (2,1))
    plt = contourf(xs, ys, zs)
    scatter!(plt, sdata, title=tit(solver.vparams[:variable]), titlefontsize=10)
    push!(plts, plt)
end
plot(plts..., layout=(2,2))
```

and produces 

<img width="712" alt="Screen Shot 2020-06-03 at 6 18 06 pm" src="https://user-images.githubusercontent.com/4486578/83613052-96c7b700-a5c6-11ea-83d8-059f3ceb157e.png">

